### PR TITLE
Enable sustained keyboard notes

### DIFF
--- a/src/audio/synthMono.ts
+++ b/src/audio/synthMono.ts
@@ -2,12 +2,18 @@ export class SynthMono {
   private ctx: AudioContext;
   private _out: GainNode;
   private vcf: BiquadFilterNode;
+  private active: Map<number, { osc: OscillatorNode; vca: GainNode }>;
 
   constructor(ctx: AudioContext) {
     this.ctx = ctx;
     this._out = new GainNode(ctx, { gain: 0.9 });
-    this.vcf = new BiquadFilterNode(ctx, { type: "lowpass", frequency: 4000, Q: 1.5 });
+    this.vcf = new BiquadFilterNode(ctx, {
+      type: "lowpass",
+      frequency: 4000,
+      Q: 1.5,
+    });
     this.vcf.connect(this._out);
+    this.active = new Map();
   }
 
   get out() {
@@ -15,7 +21,17 @@ export class SynthMono {
   }
 
   note({ freq = 440, dur = 0.3, when = this.ctx.currentTime }) {
-    const osc = new OscillatorNode(this.ctx, { type: "sawtooth", frequency: freq });
+    this.noteOn({ freq, when });
+    this.noteOff({ freq, when: when + dur });
+  }
+
+  noteOn({ freq = 440, when = this.ctx.currentTime }) {
+    if (this.active.has(freq)) return;
+
+    const osc = new OscillatorNode(this.ctx, {
+      type: "sawtooth",
+      frequency: freq,
+    });
     const vca = new GainNode(this.ctx, { gain: 0 });
     osc.connect(vca);
     vca.connect(this.vcf);
@@ -23,21 +39,32 @@ export class SynthMono {
     const attack = 0.2;
     const decay = 0.6;
     const sustain = 0.2;
-    const release = 0.4;
     const t0 = when;
     const t1 = t0 + attack;
     const t2 = t1 + decay;
-    const t3 = t0 + dur;
 
     const g = vca.gain;
     g.cancelAndHoldAtTime(t0);
     g.setValueAtTime(0.0001, t0);
     g.exponentialRampToValueAtTime(1, t1);
     g.exponentialRampToValueAtTime(sustain, t2);
-    g.setValueAtTime(sustain, t3);
-    g.exponentialRampToValueAtTime(0.0001, t3 + release);
 
     osc.start(t0);
-    osc.stop(t3 + release + 0.02);
+    this.active.set(freq, { osc, vca });
+  }
+
+  noteOff({ freq = 440, when = this.ctx.currentTime }) {
+    const active = this.active.get(freq);
+    if (!active) return;
+
+    const release = 0.4;
+    const g = active.vca.gain;
+    const t0 = when;
+    g.cancelAndHoldAtTime(t0);
+    g.setValueAtTime(g.value, t0);
+    g.exponentialRampToValueAtTime(0.0001, t0 + release);
+
+    active.osc.stop(t0 + release + 0.02);
+    this.active.delete(freq);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,10 +38,31 @@ window.addEventListener("keydown", (e) => {
     p: 96,
   };
   const midi = keyMap[e.key.toLowerCase()];
+  if (midi !== undefined && !e.repeat) {
+    const now = engine.context.currentTime;
+    console.log(`${now}: key ${e.key} -> note on ${midi}`);
+    synth.noteOn({ freq: midiToFreq(midi), when: now });
+  }
+});
+
+window.addEventListener("keyup", (e) => {
+  const keyMap: Record<string, number> = {
+    q: 60,
+    w: 64,
+    e: 67,
+    r: 72,
+    t: 76,
+    z: 79,
+    u: 84,
+    i: 88,
+    o: 91,
+    p: 96,
+  };
+  const midi = keyMap[e.key.toLowerCase()];
   if (midi !== undefined) {
     const now = engine.context.currentTime;
-    console.log(`${now}: key ${e.key} -> note ${midi}`);
-    synth.note({ freq: midiToFreq(midi), dur: 0.8, when: now });
+    console.log(`${now}: key ${e.key} -> note off ${midi}`);
+    synth.noteOff({ freq: midiToFreq(midi), when: now });
   }
 });
 
@@ -51,7 +72,8 @@ engine.onSchedule = (now: number, until: number) => {
   const endBeat = Math.floor((until - engine.beatStartTime) / spb) + 1;
 
   for (let b = startBeat; b < endBeat; b++) {
-    const barBeat = ((b % engine.loopBeats) + engine.loopBeats) % engine.loopBeats;
+    const barBeat =
+      ((b % engine.loopBeats) + engine.loopBeats) % engine.loopBeats;
 
     for (const ev of pattern) {
       if (Math.floor(ev.beat) === barBeat) {
@@ -73,7 +95,9 @@ engine.onSchedule = (now: number, until: number) => {
 const btnStart = document.getElementById("start");
 const btnPlay = document.getElementById("play");
 const btnStop = document.getElementById("stop");
-const tempoIn: HTMLInputElement | null = document.getElementById("tempo") as HTMLInputElement;
+const tempoIn: HTMLInputElement | null = document.getElementById(
+  "tempo",
+) as HTMLInputElement;
 
 btnStart?.addEventListener("click", async () => {
   await engine.resume();
@@ -95,7 +119,9 @@ tempoIn?.addEventListener("change", () => {
   const v = Number(tempoIn.value) || 120;
   // keep phase-aligned by recomputing beatStartTime so the current beat stays continuous
   const now = engine.context.currentTime;
-  const beat = engine.isPlaying ? (now - engine.beatStartTime) / engine.secondsPerBeat() : engine.playheadBeat;
+  const beat = engine.isPlaying
+    ? (now - engine.beatStartTime) / engine.secondsPerBeat()
+    : engine.playheadBeat;
   engine.tempo = Math.max(40, Math.min(240, v));
   engine.beatStartTime = now - engine.beatsToSeconds(beat);
 });


### PR DESCRIPTION
## Summary
- sustain notes until key release with ADSR-controlled start and stop
- listen for keyup events to trigger release phase

## Testing
- `npm run lint` (fails: ESLint couldn't find a config file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1c98e0ce0832a9d29df46bf68c4d6