### PR TITLE
feat: add interactive piano roll scheduler

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,12 +8,35 @@
   <body>
     <button id="start">Start</button>
     <button id="play">Play</button>
+    <button id="pause">Pause</button>
     <button id="stop">Stop</button>
     <label>
       Tempo
       <input type="number" id="tempo" min="40" max="240" value="120" />
     </label>
     <button id="testNote">Play a note once</button>
+    <div id="board"></div>
+    <style>
+      #board {
+        position: relative;
+        margin-top: 1rem;
+        border: 1px solid #555;
+        background-color: #222;
+        background-image:
+          linear-gradient(to right, #555 1px, transparent 1px),
+          linear-gradient(to bottom, #555 1px, transparent 1px);
+        background-size: 40px 40px;
+      }
+
+      .note {
+        position: absolute;
+        background: #3cf;
+        border: 1px solid #08c;
+        border-radius: 4px;
+        box-sizing: border-box;
+        cursor: move;
+      }
+    </style>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -14,7 +14,8 @@ export class AudioEngine {
   onSchedule: any;
 
   constructor() {
-    this.ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    this.ctx = new (window.AudioContext ||
+      (window as any).webkitAudioContext)();
     this._master = new GainNode(this.ctx, { gain: 0.1 });
     const compressor = new DynamicsCompressorNode(this.ctx);
     this._master.connect(compressor);
@@ -62,6 +63,10 @@ export class AudioEngine {
 
   get loopBeats(): number {
     return this._loopBeats;
+  }
+
+  set loopBeats(value: number) {
+    this._loopBeats = value;
   }
 
   get isPlaying(): boolean {
@@ -138,7 +143,13 @@ export class AudioEngine {
   play() {
     if (this._isPlaying) return;
     this._isPlaying = true;
-    this._beatStartTime = this.context.currentTime - this.beatsToSeconds(this._playheadBeat);
+    this._beatStartTime =
+      this.context.currentTime - this.beatsToSeconds(this._playheadBeat);
+  }
+
+  pause() {
+    this._isPlaying = false;
+    this._events.length = 0;
   }
 
   stop() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,19 +4,108 @@ import { SynthMono } from "./audio/synthMono";
 import { midiToFreq } from "./utils";
 
 const engine = new AudioEngine();
+engine.loopBeats = 16;
 const synth = new SynthMono(engine.context);
 const metro = new Metronome(engine.context);
 
 synth.out.connect(engine.master);
 metro.out.connect(engine.master);
 
-// 1-bar pattern: quarter notes C4 E4 G4 C5
-const pattern = [
-  { beat: 0, midi: 60, dur: 0.25 },
-  { beat: 1, midi: 64, dur: 0.25 },
-  { beat: 2, midi: 67, dur: 0.25 },
-  { beat: 3, midi: 72, dur: 0.25 },
+const BEATS = 16;
+const BEAT_WIDTH = 40;
+const ROW_HEIGHT = 40;
+const PITCHES = [72, 67, 64, 60];
+
+interface NoteEvt {
+  beat: number;
+  midi: number;
+  dur: number;
+  el: HTMLDivElement;
+}
+
+const board = document.getElementById("board") as HTMLDivElement;
+board.style.width = `${BEAT_WIDTH * BEATS}px`;
+board.style.height = `${ROW_HEIGHT * PITCHES.length}px`;
+
+const notes: NoteEvt[] = [
+  { beat: 0, midi: 60, dur: 1, el: document.createElement("div") },
+  { beat: 4, midi: 64, dur: 1, el: document.createElement("div") },
+  { beat: 8, midi: 67, dur: 1, el: document.createElement("div") },
+  { beat: 12, midi: 72, dur: 1, el: document.createElement("div") },
 ];
+
+for (const n of notes) {
+  initNoteEl(n);
+}
+
+function initNoteEl(n: NoteEvt) {
+  const el = n.el;
+  el.className = "note";
+  el.style.height = `${ROW_HEIGHT - 4}px`;
+  updateNoteEl(n);
+  board.appendChild(el);
+  setupDrag(n);
+}
+
+function updateNoteEl(n: NoteEvt) {
+  const row = PITCHES.indexOf(n.midi);
+  n.el.style.left = `${n.beat * BEAT_WIDTH}px`;
+  n.el.style.top = `${row * ROW_HEIGHT + 2}px`;
+  n.el.style.width = `${n.dur * BEAT_WIDTH - 4}px`;
+}
+
+function setupDrag(n: NoteEvt) {
+  let mode: "drag" | "resize" | null = null;
+  let startX = 0;
+  let startY = 0;
+  let startBeat = 0;
+  let startRow = 0;
+  let startDur = 0;
+
+  const onDown = (e: PointerEvent) => {
+    e.preventDefault();
+    const rect = n.el.getBoundingClientRect();
+    if (e.clientX > rect.right - 10) {
+      mode = "resize";
+    } else {
+      mode = "drag";
+    }
+    startX = e.clientX;
+    startY = e.clientY;
+    startBeat = n.beat;
+    startRow = PITCHES.indexOf(n.midi);
+    startDur = n.dur;
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
+  const onMove = (e: PointerEvent) => {
+    if (!mode) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    if (mode === "drag") {
+      let beat = Math.round((startBeat * BEAT_WIDTH + dx) / BEAT_WIDTH);
+      beat = Math.max(0, Math.min(BEATS - n.dur, beat));
+      let row = Math.round((startRow * ROW_HEIGHT + dy) / ROW_HEIGHT);
+      row = Math.max(0, Math.min(PITCHES.length - 1, row));
+      n.beat = beat;
+      n.midi = PITCHES[row];
+    } else if (mode === "resize") {
+      let dur = Math.round((startDur * BEAT_WIDTH + dx) / BEAT_WIDTH);
+      dur = Math.max(1, Math.min(BEATS - n.beat, dur));
+      n.dur = dur;
+    }
+    updateNoteEl(n);
+  };
+
+  const onUp = () => {
+    mode = null;
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+  };
+
+  n.el.addEventListener("pointerdown", onDown);
+}
 
 const testNoteButton = document.getElementById("testNote");
 testNoteButton?.addEventListener("click", () => {
@@ -70,14 +159,18 @@ engine.onSchedule = (now: number, until: number) => {
   const endBeat = Math.floor((until - engine.beatStartTime) / spb) + 1;
 
   for (let b = startBeat; b < endBeat; b++) {
-    const barBeat = ((b % engine.loopBeats) + engine.loopBeats) % engine.loopBeats;
+    const barBeat =
+      ((b % engine.loopBeats) + engine.loopBeats) % engine.loopBeats;
 
-    for (const ev of pattern) {
+    for (const ev of notes) {
       if (Math.floor(ev.beat) === barBeat) {
         const when = engine.beatStartTime + (b + (ev.beat - barBeat)) * spb;
         engine.scheduleAbs(when, () => {
-          console.log(`note ${ev.midi} at beat ${b + (ev.beat - barBeat)}`);
-          synth.note({ freq: midiToFreq(ev.midi), dur: ev.dur, when });
+          synth.note({
+            freq: midiToFreq(ev.midi),
+            dur: engine.beatsToSeconds(ev.dur),
+            when,
+          });
         });
       }
     }
@@ -91,8 +184,11 @@ engine.onSchedule = (now: number, until: number) => {
 
 const btnStart = document.getElementById("start");
 const btnPlay = document.getElementById("play");
+const btnPause = document.getElementById("pause");
 const btnStop = document.getElementById("stop");
-const tempoIn: HTMLInputElement | null = document.getElementById("tempo") as HTMLInputElement;
+const tempoIn: HTMLInputElement | null = document.getElementById(
+  "tempo",
+) as HTMLInputElement;
 
 btnStart?.addEventListener("click", async () => {
   await engine.resume();
@@ -105,6 +201,11 @@ btnPlay?.addEventListener("click", () => {
   console.log("Play");
 });
 
+btnPause?.addEventListener("click", () => {
+  engine.pause();
+  console.log("Pause");
+});
+
 btnStop?.addEventListener("click", () => {
   engine.stop();
   console.log("Stop");
@@ -114,7 +215,9 @@ tempoIn?.addEventListener("change", () => {
   const v = Number(tempoIn.value) || 120;
   // keep phase-aligned by recomputing beatStartTime so the current beat stays continuous
   const now = engine.context.currentTime;
-  const beat = engine.isPlaying ? (now - engine.beatStartTime) / engine.secondsPerBeat() : engine.playheadBeat;
+  const beat = engine.isPlaying
+    ? (now - engine.beatStartTime) / engine.secondsPerBeat()
+    : engine.playheadBeat;
   engine.tempo = Math.max(40, Math.min(240, v));
   engine.beatStartTime = now - engine.beatsToSeconds(beat);
 });


### PR DESCRIPTION
## Summary
- Add 16-beat piano roll board with draggable and resizable notes
- Allow audio engine to pause and set loop length dynamically
- Wire up playback controls to play, pause, stop the sequencer

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5461653f0832a8f3975cc5342e64f